### PR TITLE
Add audio editing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ and GUI helpers.
 - `GPU/` – simple GPU detection scripts for Blender.
 - `HUD/` – overlay and heads‑up display utilities.
 - `image_alteration/` – tools for cropping, scaling and processing images.
+- `audio_editing/` – simple audio trimming and conversion utilities.
 - `maths/` – quick math helpers.
 - `recording/` – screen capture and timelapse utilities.
 - `text_editing/` – text manipulation scripts.

--- a/audio_editing/audio_converter.py
+++ b/audio_editing/audio_converter.py
@@ -1,0 +1,11 @@
+from pydub import AudioSegment
+import argparse
+
+parser = argparse.ArgumentParser(description="Convert an audio file to another format.")
+parser.add_argument("input_file", help="Source audio")
+parser.add_argument("output_file", help="Converted audio path with extension")
+args = parser.parse_args()
+
+audio = AudioSegment.from_file(args.input_file)
+audio.export(args.output_file, format=args.output_file.split('.')[-1])
+

--- a/audio_editing/audio_merge.py
+++ b/audio_editing/audio_merge.py
@@ -1,0 +1,13 @@
+from pydub import AudioSegment
+import argparse
+
+parser = argparse.ArgumentParser(description="Merge multiple audio files into one.")
+parser.add_argument("input_files", nargs='+', help="List of audio files to merge")
+parser.add_argument("output_file", help="Path for merged audio")
+args = parser.parse_args()
+
+combined = AudioSegment.empty()
+for path in args.input_files:
+    combined += AudioSegment.from_file(path)
+combined.export(args.output_file, format=args.output_file.split('.')[-1])
+

--- a/audio_editing/audio_normalizer.py
+++ b/audio_editing/audio_normalizer.py
@@ -1,0 +1,14 @@
+from pydub import AudioSegment
+import argparse
+
+parser = argparse.ArgumentParser(description="Normalize an audio file to a target dBFS level.")
+parser.add_argument("input_file", help="Audio file to normalize")
+parser.add_argument("output_file", help="Path for the normalized audio")
+parser.add_argument("--target-dBFS", type=float, default=-20.0, dest="target", help="Target loudness in dBFS")
+args = parser.parse_args()
+
+audio = AudioSegment.from_file(args.input_file)
+change_in_dBFS = args.target - audio.dBFS
+normalized = audio.apply_gain(change_in_dBFS)
+normalized.export(args.output_file, format=args.output_file.split('.')[-1])
+

--- a/audio_editing/audio_trim.py
+++ b/audio_editing/audio_trim.py
@@ -1,0 +1,14 @@
+from pydub import AudioSegment
+import argparse
+
+parser = argparse.ArgumentParser(description="Trim an audio file to a start and end time in seconds.")
+parser.add_argument("input_file", help="Path to the source audio file")
+parser.add_argument("start", type=float, help="Start time in seconds")
+parser.add_argument("end", type=float, help="End time in seconds")
+parser.add_argument("output_file", help="Where to save the trimmed audio")
+args = parser.parse_args()
+
+audio = AudioSegment.from_file(args.input_file)
+trimmed = audio[args.start * 1000: args.end * 1000]
+trimmed.export(args.output_file, format=args.output_file.split('.')[-1])
+

--- a/script_tags.json
+++ b/script_tags.json
@@ -259,6 +259,50 @@
       "moviepy"
     ]
   },
+  "audio_editing/audio_trim.py": {
+    "tags": [
+      "audio",
+      "trim",
+      "pydub"
+    ],
+    "usage": 0,
+    "deps": [
+      "pydub"
+    ]
+  },
+  "audio_editing/audio_normalizer.py": {
+    "tags": [
+      "audio",
+      "normalize",
+      "pydub"
+    ],
+    "usage": 0,
+    "deps": [
+      "pydub"
+    ]
+  },
+  "audio_editing/audio_converter.py": {
+    "tags": [
+      "audio",
+      "convert",
+      "pydub"
+    ],
+    "usage": 0,
+    "deps": [
+      "pydub"
+    ]
+  },
+  "audio_editing/audio_merge.py": {
+    "tags": [
+      "audio",
+      "merge",
+      "pydub"
+    ],
+    "usage": 0,
+    "deps": [
+      "pydub"
+    ]
+  },
   "utils/__init__.py": {
     "tags": [
       "init",


### PR DESCRIPTION
## Summary
- add a new `audio_editing` folder
- implement basic trimming, normalization, conversion, and merge scripts using pydub
- document the new folder in the README
- register new scripts in `script_tags.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684442135498832d9cb379ae083b4040