### PR TITLE
Add modular quick form builder

### DIFF
--- a/document_builders/form_modules/base.py
+++ b/document_builders/form_modules/base.py
@@ -1,0 +1,13 @@
+import tkinter as tk
+
+class FormComponent:
+    """Base class for form components."""
+
+    name = "Base"
+
+    def __init__(self, master: tk.Misc):
+        self.frame = tk.Frame(master)
+
+    def render(self) -> str:
+        """Return the text output for this component."""
+        return ""

--- a/document_builders/form_modules/basic_text.py
+++ b/document_builders/form_modules/basic_text.py
@@ -1,0 +1,27 @@
+import tkinter as tk
+from .base import FormComponent
+
+class Component(FormComponent):
+    """Simple title and body text component."""
+
+    name = "Basic Text"
+
+    def __init__(self, master: tk.Misc):
+        super().__init__(master)
+        tk.Label(self.frame, text="Title:").grid(row=0, column=0, sticky="w")
+        self.title = tk.Entry(self.frame, width=40)
+        self.title.grid(row=0, column=1, sticky="ew")
+
+        tk.Label(self.frame, text="Body:").grid(row=1, column=0, sticky="nw")
+        self.body = tk.Text(self.frame, width=40, height=4)
+        self.body.grid(row=1, column=1, sticky="ew")
+
+    def render(self) -> str:
+        title = self.title.get().strip()
+        body = self.body.get("1.0", tk.END).strip()
+        parts = []
+        if title:
+            parts.append(title)
+        if body:
+            parts.append(body)
+        return "\n".join(parts) + "\n"

--- a/document_builders/form_modules/character_profile.py
+++ b/document_builders/form_modules/character_profile.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+from .base import FormComponent
+
+class Component(FormComponent):
+    """Character profile component."""
+
+    name = "Character Profile"
+
+    def __init__(self, master: tk.Misc):
+        super().__init__(master)
+        tk.Label(self.frame, text="Name:").grid(row=0, column=0, sticky="w")
+        self.name_entry = tk.Entry(self.frame, width=30)
+        self.name_entry.grid(row=0, column=1, sticky="ew")
+
+        tk.Label(self.frame, text="Age:").grid(row=1, column=0, sticky="w")
+        self.age_entry = tk.Entry(self.frame, width=10)
+        self.age_entry.grid(row=1, column=1, sticky="w")
+
+        tk.Label(self.frame, text="Description:").grid(row=2, column=0, sticky="nw")
+        self.desc = tk.Text(self.frame, width=40, height=3)
+        self.desc.grid(row=2, column=1, sticky="ew")
+
+    def render(self) -> str:
+        name = self.name_entry.get().strip()
+        age = self.age_entry.get().strip()
+        desc = self.desc.get("1.0", tk.END).strip()
+        lines = []
+        if name:
+            lines.append(f"Name: {name}")
+        if age:
+            lines.append(f"Age: {age}")
+        if desc:
+            lines.append(desc)
+        return "\n".join(lines) + "\n"

--- a/quick_form_maker.py
+++ b/quick_form_maker.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Interactive form builder for generating text documents."""
+
+import importlib
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+MODULE_DIR = os.path.join(os.path.dirname(__file__), "document_builders", "form_modules")
+
+
+class FormMaker(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Quick Form Maker")
+        self.available_modules = self.load_modules()
+        self.components = []
+
+        self.module_var = tk.StringVar(self)
+        if self.available_modules:
+            self.module_var.set(self.available_modules[0].name)
+        tk.OptionMenu(self, self.module_var, *[m.name for m in self.available_modules]).pack(fill="x")
+        tk.Button(self, text="Add Component", command=self.add_component).pack(fill="x")
+
+        self.component_frame = tk.Frame(self)
+        self.component_frame.pack(fill="both", expand=True)
+
+        tk.Button(self, text="Generate Output", command=self.generate_output).pack(fill="x")
+        self.output_text = tk.Text(self, height=10)
+        self.output_text.pack(fill="both", expand=True)
+        tk.Button(self, text="Copy to Clipboard", command=self.copy_output).pack(fill="x")
+        tk.Button(self, text="Save to File", command=self.save_output).pack(fill="x")
+
+    def load_modules(self):
+        modules = []
+        for fname in os.listdir(MODULE_DIR):
+            if fname.endswith(".py") and not fname.startswith(("_", "base")):
+                module_name = f"document_builders.form_modules.{fname[:-3]}"
+                mod = importlib.import_module(module_name)
+                modules.append(mod.Component)
+        modules.sort(key=lambda c: c.name)
+        return modules
+
+    def add_component(self):
+        selected_name = self.module_var.get()
+        for comp_cls in self.available_modules:
+            if comp_cls.name == selected_name:
+                frame = tk.Frame(self.component_frame, bd=2, relief="groove", pady=2)
+                comp = comp_cls(frame)
+                comp.frame.pack(fill="x", expand=True)
+                btn = tk.Button(frame, text="Remove", command=lambda f=frame, c=comp: self.remove_component(f, c))
+                btn.pack(side="right")
+                frame.pack(fill="x", pady=2)
+                self.components.append((frame, comp))
+                break
+
+    def remove_component(self, frame, comp):
+        frame.destroy()
+        self.components = [p for p in self.components if p[1] is not comp]
+
+    def generate_output(self):
+        output = []
+        for _, comp in self.components:
+            text = comp.render().strip()
+            if text:
+                output.append(text)
+        self.output_text.delete("1.0", tk.END)
+        self.output_text.insert(tk.END, "\n\n".join(output))
+
+    def copy_output(self):
+        text = self.output_text.get("1.0", tk.END)
+        if text.strip():
+            self.clipboard_clear()
+            self.clipboard_append(text)
+            messagebox.showinfo("Copied", "Output copied to clipboard")
+
+    def save_output(self):
+        text = self.output_text.get("1.0", tk.END).strip()
+        if not text:
+            return
+        path = filedialog.asksaveasfilename(defaultextension=".txt", filetypes=[("Text", "*.txt")])
+        if path:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(text)
+            messagebox.showinfo("Saved", f"Saved to {path}")
+
+
+def main() -> None:
+    app = FormMaker()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a base class for form components
- add sample form modules (`basic_text`, `character_profile`)
- implement `quick_form_maker.py` Tkinter app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478f40588c832db4ddc94d07bc744a