### PR TITLE
Add audio utility scripts and tests

### DIFF
--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,114 @@
+import os
+import tempfile
+import wave
+import unittest
+
+from utils.audio_utils.audio_speed_change import speed_change_command
+from utils.audio_utils.audio_fade import fade_command
+from utils.audio_utils.audio_reverse import reverse_command
+from utils.audio_utils.audio_overlay import overlay_command
+from utils.audio_utils.audio_split import split_command
+from utils.audio_utils.extract_channels import channel_command
+from utils.audio_utils.trim_silence import trim_silence_command
+from utils.audio_utils.audio_join import join_command
+from utils.audio_utils.audio_loop import loop_command
+from utils.audio_utils.audio_to_mono import to_mono_command
+from utils.audio_utils.audio_normalize_ffmpeg import normalize_command
+from utils.audio_utils.audio_sample_rate import sample_rate_command
+from utils.audio_utils.audio_metadata import get_wav_metadata
+from utils.audio_utils.record_microphone import record_command
+from utils.audio_utils.drag_convert_gui import convert_to_mp3
+
+
+class TestAudioUtils(unittest.TestCase):
+    def test_speed_change_command(self):
+        self.assertEqual(
+            speed_change_command('in.wav', 'out.wav', 1.5),
+            ['ffmpeg', '-i', 'in.wav', '-filter:a', 'atempo=1.5', 'out.wav']
+        )
+
+    def test_fade_command(self):
+        cmd = fade_command('in.wav', 'out.wav', 1, 4)
+        self.assertIn('afade=t=in:st=0:d=1,afade=t=out:st=4:d=1', cmd)
+
+    def test_reverse_command(self):
+        self.assertEqual(
+            reverse_command('in.wav', 'out.wav'),
+            ['ffmpeg', '-i', 'in.wav', '-filter:a', 'areverse', 'out.wav']
+        )
+
+    def test_overlay_command(self):
+        cmd = overlay_command('a.wav', 'b.wav', 'out.wav')
+        self.assertIn('amix=inputs=2:duration=first:dropout_transition=2', cmd)
+
+    def test_split_command(self):
+        self.assertEqual(
+            split_command('in.wav', 5, 10, 'out.wav'),
+            ['ffmpeg', '-ss', '5', '-t', '10', '-i', 'in.wav', 'out.wav']
+        )
+
+    def test_channel_command(self):
+        cmd = channel_command('in.wav', 1, 'right.wav')
+        self.assertIn('FR', ' '.join(cmd))
+
+    def test_trim_silence_command(self):
+        cmd = trim_silence_command('in.wav', 'out.wav')
+        self.assertIn('silenceremove', ' '.join(cmd))
+
+    def test_join_command(self):
+        cmd = join_command(['a.wav', 'b.wav'], 'out.wav')
+        self.assertEqual(cmd.count('-i'), 2)
+        self.assertEqual(cmd[-1], 'out.wav')
+
+    def test_loop_command(self):
+        self.assertEqual(
+            loop_command('in.wav', 'out.wav', 3),
+            ['ffmpeg', '-stream_loop', '2', '-i', 'in.wav', '-c', 'copy', 'out.wav']
+        )
+
+    def test_to_mono_command(self):
+        self.assertEqual(
+            to_mono_command('in.wav', 'out.wav'),
+            ['ffmpeg', '-i', 'in.wav', '-ac', '1', 'out.wav']
+        )
+
+    def test_normalize_command(self):
+        self.assertEqual(
+            normalize_command('in.wav', 'out.wav'),
+            ['ffmpeg', '-i', 'in.wav', '-filter:a', 'loudnorm', 'out.wav']
+        )
+
+    def test_sample_rate_command(self):
+        self.assertEqual(
+            sample_rate_command('in.wav', 'out.wav', 22050),
+            ['ffmpeg', '-i', 'in.wav', '-ar', '22050', 'out.wav']
+        )
+
+    def test_get_wav_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'test.wav')
+            with wave.open(path, 'wb') as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(44100)
+                wf.writeframes(b'\x00\x00' * 44100)
+            ch, rate, dur = get_wav_metadata(path)
+            self.assertEqual(ch, 1)
+            self.assertEqual(rate, 44100)
+            self.assertAlmostEqual(dur, 1.0, places=2)
+
+    def test_record_command(self):
+        self.assertEqual(
+            record_command('out.wav', 5),
+            ['ffmpeg', '-f', 'alsa', '-i', 'default', '-t', '5', 'out.wav']
+        )
+
+    def test_convert_to_mp3(self):
+        self.assertEqual(
+            convert_to_mp3('audio.ogg'),
+            ['ffmpeg', '-i', 'audio.ogg', 'audio.mp3']
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/audio_utils/audio_fade.py
+++ b/utils/audio_utils/audio_fade.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to apply fade in and fade out."""
+import argparse
+import subprocess
+from typing import List
+
+
+def fade_command(input_file: str, output_file: str, fade_in: float, fade_out: float) -> List[str]:
+    """Return the ffmpeg command to apply fades."""
+    filter_str = f"afade=t=in:st=0:d={fade_in},afade=t=out:st={fade_out}:d={fade_in}"
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-filter:a",
+        filter_str,
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Apply audio fades")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("fade_in", type=float)
+    parser.add_argument("fade_out", type=float)
+    args = parser.parse_args()
+    cmd = fade_command(args.input_file, args.output_file, args.fade_in, args.fade_out)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_join.py
+++ b/utils/audio_utils/audio_join.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to concatenate multiple audio files."""
+import argparse
+import subprocess
+from typing import List
+
+
+def join_command(inputs: List[str], output_file: str) -> List[str]:
+    """Return the ffmpeg command using concat filter."""
+    filter_str = f"concat=n={len(inputs)}:v=0:a=1"
+    cmd = [
+        "ffmpeg",
+    ]
+    for inp in inputs:
+        cmd.extend(["-i", inp])
+    cmd.extend(["-filter_complex", filter_str, output_file])
+    return cmd
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Join audio files")
+    parser.add_argument("output_file")
+    parser.add_argument("inputs", nargs='+')
+    args = parser.parse_args()
+    cmd = join_command(args.inputs, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_loop.py
+++ b/utils/audio_utils/audio_loop.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to loop audio a given number of times."""
+import argparse
+import subprocess
+from typing import List
+
+
+def loop_command(input_file: str, output_file: str, count: int) -> List[str]:
+    """Return the ffmpeg command to loop audio."""
+    return [
+        "ffmpeg",
+        "-stream_loop",
+        str(count - 1),
+        "-i",
+        input_file,
+        "-c",
+        "copy",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Loop audio")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("count", type=int)
+    args = parser.parse_args()
+    cmd = loop_command(args.input_file, args.output_file, args.count)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_metadata.py
+++ b/utils/audio_utils/audio_metadata.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Read simple metadata from a WAV file."""
+import argparse
+import wave
+from typing import Tuple
+
+
+def get_wav_metadata(path: str) -> Tuple[int, int, float]:
+    """Return (channels, sample_rate, duration_seconds)."""
+    with wave.open(path, 'rb') as wf:
+        channels = wf.getnchannels()
+        rate = wf.getframerate()
+        frames = wf.getnframes()
+    duration = frames / float(rate)
+    return channels, rate, duration
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show WAV metadata")
+    parser.add_argument("path")
+    args = parser.parse_args()
+    channels, rate, dur = get_wav_metadata(args.path)
+    print(f"Channels: {channels}\nRate: {rate}\nDuration: {dur:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_normalize_ffmpeg.py
+++ b/utils/audio_utils/audio_normalize_ffmpeg.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to normalize audio loudness."""
+import argparse
+import subprocess
+from typing import List
+
+
+def normalize_command(input_file: str, output_file: str) -> List[str]:
+    """Return the ffmpeg command to normalize audio using loudnorm."""
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-filter:a",
+        "loudnorm",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Normalize audio loudness")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = normalize_command(args.input_file, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_overlay.py
+++ b/utils/audio_utils/audio_overlay.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to overlay two audio files."""
+import argparse
+import subprocess
+from typing import List
+
+
+def overlay_command(base_file: str, overlay_file: str, output_file: str) -> List[str]:
+    """Return the ffmpeg command to mix two audio files."""
+    return [
+        "ffmpeg",
+        "-i",
+        base_file,
+        "-i",
+        overlay_file,
+        "-filter_complex",
+        "amix=inputs=2:duration=first:dropout_transition=2",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Overlay two audio files")
+    parser.add_argument("base_file")
+    parser.add_argument("overlay_file")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = overlay_command(args.base_file, args.overlay_file, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_reverse.py
+++ b/utils/audio_utils/audio_reverse.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to reverse an audio file."""
+import argparse
+import subprocess
+from typing import List
+
+
+def reverse_command(input_file: str, output_file: str) -> List[str]:
+    """Return the ffmpeg command to reverse *input_file*."""
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-filter:a",
+        "areverse",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reverse audio")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = reverse_command(args.input_file, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_sample_rate.py
+++ b/utils/audio_utils/audio_sample_rate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to change the sample rate of audio."""
+import argparse
+import subprocess
+from typing import List
+
+
+def sample_rate_command(input_file: str, output_file: str, rate: int) -> List[str]:
+    """Return the ffmpeg command to resample audio."""
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-ar",
+        str(rate),
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Change audio sample rate")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("rate", type=int)
+    args = parser.parse_args()
+    cmd = sample_rate_command(args.input_file, args.output_file, args.rate)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_speed_change.py
+++ b/utils/audio_utils/audio_speed_change.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to change audio playback speed."""
+import argparse
+import subprocess
+from typing import List
+
+
+def speed_change_command(input_file: str, output_file: str, speed: float) -> List[str]:
+    """Return the ffmpeg command to change playback speed."""
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-filter:a",
+        f"atempo={speed}",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Change audio playback speed")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("speed", type=float)
+    args = parser.parse_args()
+    cmd = speed_change_command(args.input_file, args.output_file, args.speed)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_split.py
+++ b/utils/audio_utils/audio_split.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to extract a portion of an audio file."""
+import argparse
+import subprocess
+from typing import List
+
+
+def split_command(input_file: str, start: float, duration: float, output_file: str) -> List[str]:
+    """Return the ffmpeg command to slice the audio."""
+    return [
+        "ffmpeg",
+        "-ss",
+        str(start),
+        "-t",
+        str(duration),
+        "-i",
+        input_file,
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract part of an audio file")
+    parser.add_argument("input_file")
+    parser.add_argument("start", type=float)
+    parser.add_argument("duration", type=float)
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = split_command(args.input_file, args.start, args.duration, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/audio_to_mono.py
+++ b/utils/audio_utils/audio_to_mono.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to convert audio to mono."""
+import argparse
+import subprocess
+from typing import List
+
+
+def to_mono_command(input_file: str, output_file: str) -> List[str]:
+    """Return the ffmpeg command to convert audio to mono."""
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-ac",
+        "1",
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert audio to mono")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = to_mono_command(args.input_file, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/drag_convert_gui.py
+++ b/utils/audio_utils/drag_convert_gui.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""GUI helper to convert audio files to MP3 using ffmpeg.
+
+Files can be provided on the command line (e.g. dragging onto the script)
+or selected through a file dialog.
+"""
+import argparse
+import os
+import subprocess
+import tkinter as tk
+from tkinter import filedialog
+from typing import List
+
+
+def convert_to_mp3(path: str) -> List[str]:
+    """Return the ffmpeg command to convert *path* to an MP3 next to it."""
+    base, _ = os.path.splitext(path)
+    output = base + ".mp3"
+    return ["ffmpeg", "-i", path, output]
+
+
+def run_conversion(paths: List[str]) -> None:
+    for p in paths:
+        cmd = convert_to_mp3(p)
+        subprocess.run(cmd, check=True)
+
+
+def select_files() -> List[str]:
+    root = tk.Tk()
+    root.withdraw()
+    files = filedialog.askopenfilenames(title="Select audio files")
+    root.update()
+    root.destroy()
+    return list(files)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert audio files to MP3")
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+    files = args.files or select_files()
+    if files:
+        run_conversion(list(files))
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/extract_channels.py
+++ b/utils/audio_utils/extract_channels.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to extract a single channel from stereo audio."""
+import argparse
+import subprocess
+from typing import List
+
+
+def channel_command(input_file: str, channel: int, output_file: str) -> List[str]:
+    """Return the ffmpeg command to extract left (0) or right (1) channel."""
+    filter_str = f"channelsplit=channel_layout=stereo:channels={['FL','FR'][channel]}"
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-filter_complex",
+        filter_str,
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract a single audio channel")
+    parser.add_argument("input_file")
+    parser.add_argument("channel", type=int, choices=[0, 1], help="0=left, 1=right")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+    cmd = channel_command(args.input_file, args.channel, args.output_file)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/record_microphone.py
+++ b/utils/audio_utils/record_microphone.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to record from the default microphone."""
+import argparse
+import subprocess
+from typing import List
+
+
+def record_command(output_file: str, duration: int) -> List[str]:
+    """Return the ffmpeg command to record audio."""
+    return [
+        "ffmpeg",
+        "-f",
+        "alsa",
+        "-i",
+        "default",
+        "-t",
+        str(duration),
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Record microphone")
+    parser.add_argument("output_file")
+    parser.add_argument("duration", type=int, help="Duration in seconds")
+    args = parser.parse_args()
+    cmd = record_command(args.output_file, args.duration)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/audio_utils/trim_silence.py
+++ b/utils/audio_utils/trim_silence.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Create an ffmpeg command to trim silence from start and end."""
+import argparse
+import subprocess
+from typing import List
+
+
+def trim_silence_command(input_file: str, output_file: str, threshold: str = '0.1') -> List[str]:
+    """Return the ffmpeg command to remove silence using silenceremove filter."""
+    filter_str = f"silenceremove=start_periods=1:start_threshold={threshold}:" \
+                 f"detection=peak,end_periods=1:end_threshold={threshold}"
+    return [
+        "ffmpeg",
+        "-i",
+        input_file,
+        "-af",
+        filter_str,
+        output_file,
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Trim silence from audio")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("--threshold", default="0.1")
+    args = parser.parse_args()
+    cmd = trim_silence_command(args.input_file, args.output_file, args.threshold)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add drag-and-drop MP3 converter GUI and various FFmpeg helper scripts
- expose simple functions for audio operations
- include comprehensive tests for new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cad45e4c832d978327d217c44919